### PR TITLE
chore: bump versin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # Dockerfile used in execution of Github Action
-FROM nixos/nix:2.25.2
-
-# NOTE(pete): Pin to a specific version for reproducibility.  This SHA was latest as of 20241122
-RUN nix-channel --update nixpkgs https://github.com/NixOS/nixpkgs/archive/23e89b7da85c3640bbc2173fe04f4bd114342367.tar.gz
+FROM nixos/nix:2.26.3
 
 RUN nix-env -i terragrunt opentofu sudo curl gnused jq git
 


### PR DESCRIPTION
Bump version number and remove nix-channel pinning.